### PR TITLE
fixed single quotes with variable extrapolations, added missing APIs

### DIFF
--- a/docs/30-cleanup.md
+++ b/docs/30-cleanup.md
@@ -1,21 +1,21 @@
 # Clean up
 
-If you no longer want to keep your application running, you need to clean it up. 
+If you no longer want to keep your application running, you need to clean it up.
 
-If you chose to create a new Google Cloud Platform project just for this app, then you can cleanup by deleting the entire project. 
+If you chose to create a new Google Cloud Platform project just for this app, then you can cleanup by deleting the entire project.
 
 
 To avoid incurring charges to your Google Cloud Platform account for the resources used in this tutorial:
  * In the Cloud Console, go to the [Manage resources](https://console.cloud.google.com/cloud-resource-manager) page.
  * In the project list, select your project then click Delete.
  * In the dialog, type the project ID and then click Shut down to delete the project.
- 
+
 ## Destroy all resources with terraform if you want keep your project
 
 ```shell
 terraform destroy \
-  -var 'region=${REGION}' \
-  -var 'service=${SERVICE_NAME}' \
-  -var 'project=${PROJECT_ID}' \
-  -var 'instance_name=${SERVICE_NAME}'
+  -var "region=${REGION}" \
+  -var "service=${SERVICE_NAME}" \
+  -var "project=${PROJECT_ID}" \
+  -var "instance_name=${SERVICE_NAME}"
 ```


### PR DESCRIPTION
Hey Micka, here are a few fixes and some suggestions and behavior I encountered when testing the project. I took some notes while following the steps, but it's quite clear how everything is supposed to work and actually had fun doing it :) great work!

Suggestion:

- Define te global requirements to run the project with project version (such as Docker, Docker Compose, Composer, Terraform, gcloud, etc.

Locally:

- No `.env` file in repo by default, it makes `docker-compose up` fail - maybe document the need for `.env` or commit an empty one
- Why is `composer install` required?
- I'd recommend not to have `.gitignore` files hidden in sub-directories to avoid surprise as to really ignored files
- Had an exception from Laravel when trying `localhost` after startup as `storage/logs` was not writable by container (folder has my own user rights), added `0777` permissions - maybe it can be worked around by mounting a volume in Docker on this folder?

Deployment:

- Why use export `PROJECT_ID=YourProjectID` before config?
- Owner rights? o_o Can't we give specific rights on services?
-  What are `SERVICE_NAME=serviceName` and `INSTANCE_NAME`  for? (has my answer later when using `gcloud` commands, but it would be nice to mention it)
- Maybe do not use `$` in front of commands so it can be copy-pasted easily (actually I changed that in the MR - feel free to change it if that does not suit you)
- When using `gcloud auth application-default login` had error message 
  ```
  The environment variable [GOOGLE_APPLICATION_CREDENTIALS] is set to:
  [/home/pbeucher/terraform-key.json]
  Credentials will still be generated to the default location:
  [/home/pbeucher/.config/gcloud/application_default_credentials.json]
  To use these credentials, unset this environment variable before
  running your application.
  ```
  not sure it worked as expected or we had to user either SA or this method
- `Instead the Editor role gives access to do most things`didn't we just authenticate as owner by setting `--role roles/owner` previously ?
- container registry link redirect to `https://console.cloud.google.com/apis/api/containerregistry.googleapis.com/overview?project=sacred-particle-277009` which I believe is your own project ;) (later note: I updated instructions to mention some required APIs but may have missed some, actually only had to enable those that were not activated on my account)
- Had error `unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication`, solved by using
  ```
  gcloud auth activate-service-account ACCOUNT --key-file=KEY-FILE
  gcloud auth configure-docker
  ```
  I may have gotten something wrong when authenticating in the first place though, but using service account seems to require these steps. 
- `terraform apply  -var 'region=${REGION}' ...` must use `"` instead of `'` otherwise variable won't be extrapolated (I added that to the MR)
- Need to enable more APIs (see MR)
- Had this error on first run, re-running a second time worked fine - maybe due to some latency in SA availability
  ```
  Error: Request "Set IAM Binding for role \"roles/run.admin\" on \"project \\\"sandbox-crafteo\\\"\"" returned error: Batch request and retried single request "Set IAM Binding for role \"roles/run.admin\" on \"project \\\"sandbox-crafteo\\\"\"" both failed. Final error: Error applying IAM policy for project "sandbox-crafteo": Error setting IAM policy for project "sandbox-crafteo": googleapi: Error 400: Service account 502807708800@cloudbuild.gserviceaccount.com does not exist., badRequest

  on modules/config/iam.tf line 21, in resource "google_project_iam_binding" "service_permissions":
	  21: resource google_project_iam_binding service_permissions {

  Error: Error applying IAM policy for service account 'projects/sandbox-crafteo/serviceAccounts/test-laravel@sandbox-crafteo.iam.gserviceaccount.com': Error setting IAM policy for service account 'projects/sandbox-crafteo/serviceAccounts/test-laravel@sandbox-crafteo.iam.gserviceaccount.com': googleapi: Error 400: Service account 502807708800@cloudbuild.gserviceaccount.com does not exist., badRequest

  on modules/config/iam.tf line 31, in resource "google_service_account_iam_binding" "cloudbuild_sa":
	  31: resource google_service_account_iam_binding cloudbuild_sa {
  ```

- `.cloudbuild/build-migrate-deploy` seems to contain a full Docker build - as image was already built during tutorial, is it necessary? It looks like only the `migrate` job is required here 
- Got error when running `Run your seeder`
  ```
  In DatabaseServiceProvider.php line 78:
                                   
    Class 'Faker\Factory' not found
  ```